### PR TITLE
Should keep composer.lock in the repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Thumbs.db
 Gemfile.lock
 
 # fuel
-/composer.lock
 fuel/app/cache/*
 fuel/app/logs/*
 fuel/app/tmp/*


### PR DESCRIPTION
See: https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
and
http://stackoverflow.com/a/12896850
