### PR TITLE
Moved contributing out of readme into file recognized by github issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+## Contributing
+
+#### General Changes
+1. [Fork the repository](https://help.github.com/articles/fork-a-repo)
+2. [Create a topic branch](http://learn.github.com/p/branching.html)
+3. [Add, commit and push your changes](http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository)
+4. [Submit a pull request](https://help.github.com/articles/using-pull-requests)
+
+#### Payment Gateways
+
+Volcano's Payment Gateway system utilizes the [adapter design pattern](http://en.wikipedia.org/wiki/Adapter_pattern). The adapter allows the system to interface with a variety of billing drivers (Authorize.net, Stripe, PayPal, etc). Currently, Authorize.net is the only supported payment gateway. However, additional gateways can easily be added:
+
+1. Create a new directory within `/fuel/app/classes/gateway` for the new gateway driver.
+2. Within this new directory, add `driver.php`, `customer.php`, `paymentmethod.php` and `transaction.php`  files. Each of these files should contain CRUD logic specific to the new driver. Refer to the authorizenet driver as a general guide for how to name the classes and structure code.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-Volcano is an API-first billing solution that is capable of interfacing with [a variety of payment gateways](#gateways). Volcano offers both a robust, RESTful API as well as a fully-featured front-end control panel.
+Volcano is an API-first billing solution that is capable of interfacing with a variety of payment gateways. Volcano offers both a robust, RESTful API as well as a fully-featured front-end control panel.
 
 ## Mission
 Volcano is meant to be a flexible, gateway-agnostic billing system. The system can be setup with one or more sellers, each of which has its own set of configurable products and customer base. Volcano's core elements include sellers, customers, products, product options, product fees, orders and transactions. Current goals for the project include additional features for these core elements and new light-weight CRM tools such as customer support ticket management.
@@ -78,19 +78,3 @@ Create a Customer:
 Create a Multi-Product Order for a Customer:
 
 	$ http -f POST volcano.dev/api/customers/120488428/orders products[4]="myappdomain.com" products[7]="My App Instance"
-
-
-## Contributing
-
-#### General Changes
-1. [Fork the repository](https://help.github.com/articles/fork-a-repo)
-2. [Create a topic branch](http://learn.github.com/p/branching.html)
-3. [Add, commit and push your changes](http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository)
-4. [Submit a pull request](https://help.github.com/articles/using-pull-requests)
-
-#### Payment Gateways <a name="gateways"></a>
-
-Volcano's Payment Gateway system utilizes the [adapter design pattern](http://en.wikipedia.org/wiki/Adapter_pattern). The adapter allows the system to interface with a variety of billing drivers (Authorize.net, Stripe, PayPal, etc). Currently, Authorize.net is the only supported payment gateway. However, additional gateways can easily be added:
-
-1. Create a new directory within `/fuel/app/classes/gateway` for the new gateway driver.
-2. Within this new directory, add `driver.php`, `customer.php`, `paymentmethod.php` and `transaction.php`  files. Each of these files should contain CRUD logic specific to the new driver. Refer to the authorizenet driver as a general guide for how to name the classes and structure code.


### PR DESCRIPTION
What do you think about moving the info from readme to a contributing file? When you try to open an issue it will ask you to review the guidelines and is helpful. Many large projects use this to deter not researching duplicate issues and enforcing coding standards.

You can read about it on the [GitHub help](https://help.github.com/articles/how-do-i-set-up-guidelines-for-contributors) and the [GitHub blog](https://github.com/blog/1184-contributing-guidelines).
